### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/app/views/custom_fields.py
+++ b/app/views/custom_fields.py
@@ -25,7 +25,7 @@ class CKTextAreaWidget(widgets.TextArea):
     def __call__(self, field, **kwargs):
         # add WYSIWYG class to existing classes
         existing_classes = kwargs.pop('class', '') or kwargs.pop('class_', '')
-        kwargs['class'] = u'%s %s' % (existing_classes, "ckeditor")
+        kwargs['class'] = u'{0!s} {1!s}'.format(existing_classes, "ckeditor")
         return super(CKTextAreaWidget, self).__call__(field, **kwargs)
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:betterlife:flask-psi?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:betterlife:flask-psi?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)